### PR TITLE
allow chardet 4.0; patch from upstream pr5333

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4
+  patches:
+    - pr5333.patch
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py2k]
 
@@ -25,7 +27,7 @@ requirements:
     - python
     - async-timeout <4.0,>=3.0
     - attrs >=17.3.0
-    - chardet >=2.0,<4.0
+    - chardet >=2.0,<5.0
     - idna_ssl >=1.0  # [py<37]
     - multidict >=4.5,<7.0
     - typing-extensions >=3.6.5

--- a/recipe/pr5333.patch
+++ b/recipe/pr5333.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 428df5d..54462ba 100644
+--- a/setup.py
++++ b/setup.py
+@@ -66,7 +66,7 @@ except IndexError:
+ 
+ install_requires = [
+     "attrs>=17.3.0",
+-    "chardet>=2.0,<4.0",
++    "chardet>=2.0,<5.0",
+     "multidict>=4.5,<7.0",
+     "async_timeout>=3.0,<4.0",
+     "yarl>=1.0,<2.0",


### PR DESCRIPTION
We would like to support environments with chardet 4.0 and aiohttp, so we need the runtime dependency updated.
The aiohttp project updated it in pr5333 that was merged to master, but it has not been included in a release yet.
See https://github.com/aio-libs/aiohttp/pull/5333

I proposed a similar PR to conda-forge, simply applying the changes in pr5333 and it was merged (https://github.com/conda-forge/aiohttp-feedstock/pull/55)

This PR is a similar update.