### PR TITLE
Rebuild for python 3.10 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py<36]
 
@@ -51,7 +51,7 @@ about:
   license_family: Apache
   summary: Async http client/server framework (asyncio)
 
-  doc_url: http://aiohttp.readthedocs.io/
+  doc_url: https://aiohttp.readthedocs.io/
   dev_url: https://github.com/aio-libs/aiohttp
   doc_source_url: https://github.com/aio-libs/aiohttp/tree/master/docs
 


### PR DESCRIPTION
1. Bump build number
2. Fix doc url with HTTPS

Rebuild for googl-cloud-core -> gensim