### PR TITLE
PKG-2774: Updates for v3.8.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc
 
 build:
-  skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
@@ -25,9 +25,14 @@ requirements:
     - wheel
   run:
     - python
+    - attrs >=17.3.0
+    - charset-normalizer >=2.0,<4.0
     - multidict >=4.5,<7.0
-    - async-timeout >=4.0,<5.0  # [py<311]
+    - async-timeout >=4.0.0a3,<5.0
+    - asynctest ==0.13.0  # [py<38]
     - yarl >=1.0,<2.0
+    - idna_ssl >=1.0  # [py<37]
+    - typing-extensions >=3.7.4  # [py<38]
     - frozenlist >=1.1.1
     - aiosignal >=1.1.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp" %}
-{% set version = "3.8.3" %}
+{% set version = "3.8.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
-  sha256: 3828fb41b7203176b82fe5d699e0d845435f2374750a44b480ea6b930f6be269
+  sha256: b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc
 
 build:
-  skip: true  # [py<36]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
@@ -25,14 +25,9 @@ requirements:
     - wheel
   run:
     - python
-    - attrs >=17.3.0
-    - charset-normalizer >=2.0,<3.0
     - multidict >=4.5,<7.0
-    - async-timeout >=4.0.0a3,<5.0
-    - asynctest ==0.13.0  # [py<38]
+    - async-timeout >=4.0,<5.0  # [py<311]
     - yarl >=1.0,<2.0
-    - idna_ssl >=1.0  # [py<37]
-    - typing-extensions >=3.7.4  # [py<38]
     - frozenlist >=1.1.1
     - aiosignal >=1.1.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,6 @@ about:
   description: Async http client/server framework (asyncio)
   doc_url: https://docs.aiohttp.org/
   dev_url: https://github.com/aio-libs/aiohttp
-  doc_source_url: https://github.com/aio-libs/aiohttp/tree/master/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Jira: https://anaconda.atlassian.net/browse/PKG-2774

**Changes:**
- Bump to v3.8.5 and update sha256.
- Update `script` to have `--no-deps --no-build-isolation`
- Verified v3.8.5 run deps here: https://github.com/aio-libs/aiohttp/blob/v3.8.5/setup.cfg#L51-L61