### PR TITLE
update to 3.9.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+aggregate_branch: 3.12
+
+channels:
+- https://staging.continuum.io/prefect/fs/re-assert-feedstock/pr1/9c2872f
+- https://staging.continuum.io/prefect/fs/multidict-feedstock/pr7/91f99ab
+- https://staging.continuum.io/prefect/fs/yarl-feedstock/pr4/3d50762

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-- https://staging.continuum.io/prefect/fs/re-assert-feedstock/pr1/9c2872f
-- https://staging.continuum.io/prefect/fs/multidict-feedstock/pr7/91f99ab
-- https://staging.continuum.io/prefect/fs/yarl-feedstock/pr4/3d50762

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp" %}
-{% set version = "3.8.5" %}
+{% set version = "3.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
-  sha256: b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc
+  sha256: 09f23292d29135025e19e8ff4f0a68df078fe4ee013bca0105b2e803989de92d
 
 build:
-  skip: true  # [py<36]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
@@ -26,23 +26,54 @@ requirements:
   run:
     - python
     - attrs >=17.3.0
-    - charset-normalizer >=2.0,<4.0
     - multidict >=4.5,<7.0
-    - async-timeout >=4.0.0a3,<5.0
-    - asynctest ==0.13.0  # [py<38]
+    - async-timeout >=4.0,<5.0  # [py<311]
     - yarl >=1.0,<2.0
-    - idna_ssl >=1.0  # [py<37]
-    - typing-extensions >=3.7.4  # [py<38]
     - frozenlist >=1.1.1
     - aiosignal >=1.1.2
 
 test:
   imports:
     - aiohttp
-  commands:
-    - pip check
+  source_files:
+    - tests
+    - setup.cfg
+    # used by a test
+    - README.rst
   requires:
     - pip
+{% if python != "3.12" %}
+    - pytest
+    - pytest-mock
+    - pytest-cov
+    - trustme
+    - gunicorn
+    - uvloop # [not win]
+    - brotli-python
+    - re-assert
+{% endif %}
+  commands:
+    - pip check
+
+{% if python != "3.12" %}
+
+    # don't want the docker tests in the autobahn subfolder
+    - rm -rf tests/autobahn         # [unix]
+    - rmdir /s /q tests\autobahn    # [win]
+
+    {% set tests_to_skip = "_not_a_real_test" %}
+    # would requires package time-machine
+    {% set tests_to_skip = tests_to_skip + " or test_expires or test_max_age or test_cookie_jar_clear_expired" %}
+    # not sure why, they do appear in that issue: https://github.com/aio-libs/aiohttp/issues/7675
+    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_c[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_py[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_strict_headers[c-parser-pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_client_session_timeout_zero" %}
+
+    # ignore test files due to currently unavailable test dependencies (proxy.py)
+    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py
+
+{% endif %}
 
 about:
   home: https://github.com/aio-libs/aiohttp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,8 @@ test:
     - pytest-mock
     - pytest-cov
     - trustme
-    - gunicorn
-    - uvloop # [not win]
+    - gunicorn  # [not win]
+    - uvloop    # [not win]
     - brotli-python
     - re-assert
 {% endif %}
@@ -68,8 +68,12 @@ test:
     {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_c[pyloop]" %}
     {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_py[pyloop]" %}
     {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_strict_headers[c-parser-pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_access_root_of_static_handler[pyloop-index_forbidden]" %}
     {% set tests_to_skip = tests_to_skip + " or test_client_session_timeout_zero" %}
-
+    # OSError regarding socket assigment
+    {% set tests_to_skip = tests_to_skip + " or test_run_app_preexisting_inet6_socket[pyloop] " %}
+    {% set tests_to_skip = tests_to_skip + " or test_handler_cancellation" %}
+    {% set tests_to_skip = tests_to_skip + " or est_no_handler_cancellation" %}
     # ignore test files due to currently unavailable test dependencies (proxy.py)
     - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,10 @@ test:
     # OSError regarding socket assigment
     {% set tests_to_skip = tests_to_skip + " or test_run_app_preexisting_inet6_socket[pyloop] " %}
     {% set tests_to_skip = tests_to_skip + " or test_handler_cancellation" %}
-    {% set tests_to_skip = tests_to_skip + " or est_no_handler_cancellation" %}
+    {% set tests_to_skip = tests_to_skip + " or test_no_handler_cancellation" %}
+    {% set tests_to_skip = tests_to_skip + " or test_shutdown_pending_handler_responds" %}
+    # would requires package gunicorn
+    {% set tests_to_skip = tests_to_skip + " or test_no_warnings[aiohttp.worker]" %} # [win or s390x]
     # ignore test files due to currently unavailable test dependencies (proxy.py)
     - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - pytest-mock
     - pytest-cov
     - trustme
-    - gunicorn  # [not win]
+    - gunicorn  # [not (win or s390x)]
     - uvloop    # [not win]
     - brotli-python
     - re-assert


### PR DESCRIPTION
Changes:
- Update to 3.9.0
- run tests
- enable 3.12 build in abs.yaml
- do not run tests for 3.12 (because of currently missing test deps)

https://github.com/aio-libs/aiohttp/tree/v3.9.0
https://github.com/aio-libs/aiohttp/blob/v3.9.0/pyproject.toml
https://github.com/aio-libs/aiohttp/tree/v3.9.0/requirements (for tests)
https://github.com/aio-libs/aiohttp/blob/v3.9.0/setup.cfg#L115 (test config)