### PR TITLE
aiohttp 3.9.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp" %}
-{% set version = "3.9.3" %}
+{% set version = "3.9.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
-  sha256: 90842933e5d1ff760fae6caca4b2b3edba53ba8f4b71e95dacf2818a2aca06f7
+  sha256: edea7d15772ceeb29db4aff55e482d4bcfb6ae160ce144f2682de02f6d693551
 
 build:
   skip: true  # [py<38]


### PR DESCRIPTION
aiohttp 3.9.5

**Destination channel:** defaults

### Links

- [PKG-4605](https://anaconda.atlassian.net/browse/PKG-4605)
- [Upstream repository](https://github.com/aio-libs/aiohttp/tree/v3.9.5)
- [Upstream changelog/diff](https://github.com/aio-libs/aiohttp/blob/v3.9.5/CHANGES.rst)

### Explanation of changes:
- Update version


[PKG-4605]: https://anaconda.atlassian.net/browse/PKG-4605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ