### PR TITLE
3.12.15 Update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp" %}
-{% set version = "3.11.10" %}
+{% set version = "3.12.15" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
-  sha256: b1fc6b45010a8d0ff9e88f9f2418c6fd408c99c211257334aff41597ebece42e
+  sha256: 4fc61385e9c98d72fcdf47e6dd81833f47b2f77c114c29cd64a361be57a763a2
 
 build:
   skip: true  # [py<39]
@@ -53,7 +53,7 @@ test:
     - pytest-xdist
     - pytest-codspeed
     - trustme
-    - gunicorn  # [not (win or s390x)]
+    - gunicorn  # [not win]
     - uvloop    # [not win]
     - brotli-python
     - re-assert
@@ -103,7 +103,7 @@ test:
     # PytestUnraisableExceptionWarning on s390x
     {% set tests_to_skip = tests_to_skip + " or test_release_early[pyloop]" %}
     # would requires package gunicorn
-    {% set tests_to_skip = tests_to_skip + " or test_no_warnings[aiohttp.worker]" %} # [win or s390x]
+    {% set tests_to_skip = tests_to_skip + " or test_no_warnings[aiohttp.worker]" %} # [win]
     # ignore test files due to currently unavailable test dependencies (proxy.py)
     # || true because of unstable pyloop tests. (Time sensitive issues on slow CI?)
     - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || true          # [unix]
@@ -111,10 +111,10 @@ test:
 
 about:
   home: https://github.com/aio-libs/aiohttp
-  license: MIT AND Apache-2.0
+  license: Apache-2.0 AND MIT
   license_file:
     - LICENSE.txt
-    - vendor/llhttp/LICENSE-MIT
+    - vendor/llhttp/LICENSE
   license_family: Other
   summary: Async http client/server framework (asyncio)
   description: Async http client/server framework (asyncio)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,26 +82,15 @@ test:
     {% set tests_to_skip = tests_to_skip + " or test_client_session_timeout_zero" %}
     # OSError regarding socket assigment
     {% set tests_to_skip = tests_to_skip + " or test_run_app_preexisting_inet6_socket[pyloop] " %}
-    {% set tests_to_skip = tests_to_skip + " or test_handler_cancellation" %}
-    {% set tests_to_skip = tests_to_skip + " or test_no_handler_cancellation" %}
-    {% set tests_to_skip = tests_to_skip + " or test_shutdown_pending_handler_responds" %}
     {% set tests_to_skip = tests_to_skip + " or test_keepalive_timeout_sync_sleep or test_keepalive_timeout_async_sleep or test_HTTP_304[pyloop]" %}
     # CI is too slow for expected speed
     {% set tests_to_skip = tests_to_skip + " or test_import_time" %}  # [linux]
-    # Pytest terminal summary report not found
-    {% set tests_to_skip = tests_to_skip + " or test___all__" %}  # [osx]
-    {% set tests_to_skip = tests_to_skip + " or test_web___all__" %}  # [osx]
-    {% set tests_to_skip = tests_to_skip + " or test_aiohttp_plugin" %}  # [osx]
-    {% set tests_to_skip = tests_to_skip + " or test_warning_checks" %}  # [osx]
-    {% set tests_to_skip = tests_to_skip + " or test_aiohttp_plugin_async_fixture" %}  # [osx]
-    {% set tests_to_skip = tests_to_skip + " or test_aiohttp_plugin_async_gen_fixture" %}  # [osx]
-    {% set tests_to_skip = tests_to_skip + " or test_testcase_no_app" %}  # [osx]
+
     # Permission errors on linux
     {% set tests_to_skip = tests_to_skip + " or test_test_server_hostnames[::1-::1] or test_send[request_start-params0-TraceRequestStartParams]" %}  # [linux]
     # Socket assisgnemnt errors on linux
     {% set tests_to_skip = tests_to_skip + " or test_static_directory_without_read_permission or test_static_file_without_read_permission" %}  # [linux]
-    # Permission errors on linux - OSError: [Errno 99] Cannot assign requested address
-    {% set tests_to_skip = tests_to_skip + " or test_test_server_hostnames or test_send[request_start-params0-TraceRequestStartParams]" %}  # [linux]
+
     # PytestUnraisableExceptionWarning on s390x
     {% set tests_to_skip = tests_to_skip + " or test_release_early[pyloop]" %}
     # would requires package gunicorn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
     - wheel
   run:
     - python
-    - aiohappyeyeballs >=2.3.0
-    - aiosignal >=1.1.2
+    - aiohappyeyeballs >=2.5.0
+    - aiosignal >=1.4.0
     - async-timeout >=4.0,<6.0  # [py<311]
     - attrs >=17.3.0
     - frozenlist >=1.1.1
@@ -35,7 +35,7 @@ requirements:
     - propcache >=0.2.0
     - yarl >=1.17.0,<2.0
   run_constrained:
-    - aiodns >=3.2.0  # [not win]
+    - aiodns >=3.3.0  # [not win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,9 @@ requirements:
     - multidict >=4.5,<7.0
     - propcache >=0.2.0
     - yarl >=1.17.0,<2.0
-  run_constrained:
-    - aiodns >=3.3.0  # [not win]
+    # promote to run due to high recommendation from developers
+    # https://github.com/aio-libs/aiohttp/blob/acfc2e6e34e36c5afadc665ac3a6ffb5c1e00234/docs/index.rst#library-installation
+    - aiodns >=3.3.0
 
 test:
   imports:


### PR DESCRIPTION
aiohttp 3.12.15
Destination channel: defaults
Links

PKG-9014
[Upstream repository](https://github.com/aio-libs/aiohttp)
[Upstream changelog/diff](https://github.com/aio-libs/aiohttp/releases/tag/v3.12.15)
Relevant dependency PRs:

aiohappyeyeballs upgrade to >=2.5.0 (PKG-9287)
aiosignal upgrade to >=1.4.0 (PKG-9290)

Explanation of changes:

Version Update: Upgraded from 3.11.10 to 3.12.15 to address CVE-2025-53643 security vulnerability
Dependency Updates:

aiohappyeyeballs: minimum requirement increased from >=2.3.0 to >=2.5.0
aiosignal: minimum requirement increased from >=1.1.2 to >=1.4.0
aiodns: minimum requirement increased from >=3.2.0 to >=3.3.0


License Updates:

License expression updated from "MIT AND Apache-2.0" to "Apache-2.0 AND MIT"
Fixed vendor/llhttp/LICENSE-MIT path to vendor/llhttp/LICENSE
Security Fix: Addresses low-severity CVE-2025-53643 vulnerability