### PR TITLE
aiohttp 3.13.2: add py314 support 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pytest-codspeed-feedstock/pr8/0d2b39b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/yarl-feedstock/pr8/9ba103c

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
 
 channels:
-  - https://staging.continuum.io/pbp/fs/yarl-feedstock/pr8/9ba103c
+  - https://staging.continuum.io/pbp/fs/aiohappyeyeballs-feedstock/pr5/e49ed87

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,6 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
 
 channels:
-  - https://staging.continuum.io/pbp/fs/aiohappyeyeballs-feedstock/pr5/e49ed87
+  - https://staging.continuum.io/pbp/fs/eventlet-feedstock/pr8/76276c2
+  - https://staging.continuum.io/pbp/fs/gunicorn-feedstock/pr4/4e56afa
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/eventlet-feedstock/pr8/76276c2
-  - https://staging.continuum.io/pbp/fs/gunicorn-feedstock/pr4/4e56afa
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pytest-codspeed-feedstock/pr8/0d2b39b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp" %}
-{% set version = "3.12.15" %}
+{% set version = "3.13.2" %}
 {% set tests_to_skip = "_not_a_real_test" %}
 {% set tests_to_skip = tests_to_skip + " or test_expires or test_max_age or test_cookie_jar_clear_expired" %}
 {% set tests_to_skip = 'tests_to_skip + " or test_http_response_parser_bad_chunked_strict_c[pyloop]"' %}
@@ -26,7 +26,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
-  sha256: 4fc61385e9c98d72fcdf47e6dd81833f47b2f77c114c29cd64a361be57a763a2
+  sha256: 40176a52c186aefef6eb3cad2cdd30cd06e3afbe88fe8ab2af9c0b90f228daca
 
 build:
   skip: true  # [py<39]
@@ -41,7 +41,8 @@ requirements:
     - python
     - pip
     - cython
-    - setuptools >=46.4.0
+    - pkgconfig
+    - setuptools >=67.0
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,37 @@
 {% set name = "aiohttp" %}
 {% set version = "3.12.15" %}
+{% set tests_to_skip = "_not_a_real_test" %}
+{% set tests_to_skip = tests_to_skip + " or test_expires or test_max_age or test_cookie_jar_clear_expired" %}
+{% set tests_to_skip = 'tests_to_skip + " or test_http_response_parser_bad_chunked_strict_c[pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_http_response_parser_bad_chunked_strict_py[pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_http_response_parser_strict_headers[c-parser-pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_access_root_of_static_handler[pyloop-index_forbidden]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_heartbeat[pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_heartbeat_no_pong[pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_heartbeat_no_pong_after_receive_many_messages[pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_normal_closure_while_client_sends_msg[pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_close_timeout[pyloop]"' %}
+{% set tests_to_skip = tests_to_skip + " or test_client_session_timeout_zero" %}
+{% set tests_to_skip = 'tests_to_skip + " or test_run_app_preexisting_inet6_socket[pyloop] "' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_keepalive_timeout_sync_sleep or test_keepalive_timeout_async_sleep or test_HTTP_304[pyloop]"' %}
+{% set tests_to_skip = tests_to_skip + " or test_import_time" %}  # [linux]
+{% set tests_to_skip = 'tests_to_skip + " or test_test_server_hostnames[::1-::1] or test_send[request_start-params0-TraceRequestStartParams]"' %}  # [linux]
+{% set tests_to_skip = tests_to_skip + " or test_static_directory_without_read_permission or test_static_file_without_read_permission" %}  # [linux]
+{% set tests_to_skip = 'tests_to_skip + " or test_release_early[pyloop]"' %}
+{% set tests_to_skip = 'tests_to_skip + " or test_no_warnings[aiohttp.worker]"' %}  # [win]
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
   sha256: 4fc61385e9c98d72fcdf47e6dd81833f47b2f77c114c29cd64a361be57a763a2
 
 build:
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -56,49 +75,27 @@ test:
     - pytest-codspeed
     - trustme
     - gunicorn  # [not win]
-    - uvloop    # [not win]
+    - uvloop  # [not win]
     - brotli-python
     - re-assert
     - freezegun
   commands:
     - pip check
     # don't want the docker tests in the autobahn subfolder
-    - rm -rf tests/autobahn         # [unix]
-    - rmdir /s /q tests\autobahn    # [win]
-
-    {% set tests_to_skip = "_not_a_real_test" %}
+    - rm -rf tests/autobahn  # [unix]
+    - rmdir /s /q tests\autobahn  # [win]
     # would requires package time-machine
-    {% set tests_to_skip = tests_to_skip + " or test_expires or test_max_age or test_cookie_jar_clear_expired" %}
     # time sensitive issues on slow CI?
-    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_c[pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_py[pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_strict_headers[c-parser-pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_access_root_of_static_handler[pyloop-index_forbidden]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_heartbeat[pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_heartbeat_no_pong[pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_heartbeat_no_pong_after_receive_many_messages[pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_normal_closure_while_client_sends_msg[pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_close_timeout[pyloop]" %}
-    {% set tests_to_skip = tests_to_skip + " or test_client_session_timeout_zero" %}
     # OSError regarding socket assigment
-    {% set tests_to_skip = tests_to_skip + " or test_run_app_preexisting_inet6_socket[pyloop] " %}
-    {% set tests_to_skip = tests_to_skip + " or test_keepalive_timeout_sync_sleep or test_keepalive_timeout_async_sleep or test_HTTP_304[pyloop]" %}
     # CI is too slow for expected speed
-    {% set tests_to_skip = tests_to_skip + " or test_import_time" %}  # [linux]
-
     # Permission errors on linux
-    {% set tests_to_skip = tests_to_skip + " or test_test_server_hostnames[::1-::1] or test_send[request_start-params0-TraceRequestStartParams]" %}  # [linux]
     # Socket assisgnemnt errors on linux
-    {% set tests_to_skip = tests_to_skip + " or test_static_directory_without_read_permission or test_static_file_without_read_permission" %}  # [linux]
-
     # PytestUnraisableExceptionWarning on s390x
-    {% set tests_to_skip = tests_to_skip + " or test_release_early[pyloop]" %}
     # would requires package gunicorn
-    {% set tests_to_skip = tests_to_skip + " or test_no_warnings[aiohttp.worker]" %} # [win]
     # ignore test files due to currently unavailable test dependencies (proxy.py)
     # || true because of unstable pyloop tests. (Time sensitive issues on slow CI?)
-    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || true          # [unix]
-    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || exit /b 0     # [win]
+    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || true  # [unix]
+    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || exit /b 0  # [win]
 
 about:
   home: https://github.com/aio-libs/aiohttp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,5 @@
 {% set name = "aiohttp" %}
 {% set version = "3.13.2" %}
-{% set tests_to_skip = "_not_a_real_test" %}
-{% set tests_to_skip = tests_to_skip + " or test_expires or test_max_age or test_cookie_jar_clear_expired" %}
-{% set tests_to_skip = 'tests_to_skip + " or test_http_response_parser_bad_chunked_strict_c[pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_http_response_parser_bad_chunked_strict_py[pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_http_response_parser_strict_headers[c-parser-pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_access_root_of_static_handler[pyloop-index_forbidden]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_heartbeat[pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_heartbeat_no_pong[pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_heartbeat_no_pong_after_receive_many_messages[pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_normal_closure_while_client_sends_msg[pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_close_timeout[pyloop]"' %}
-{% set tests_to_skip = tests_to_skip + " or test_client_session_timeout_zero" %}
-{% set tests_to_skip = 'tests_to_skip + " or test_run_app_preexisting_inet6_socket[pyloop] "' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_keepalive_timeout_sync_sleep or test_keepalive_timeout_async_sleep or test_HTTP_304[pyloop]"' %}
-{% set tests_to_skip = tests_to_skip + " or test_import_time" %}  # [linux]
-{% set tests_to_skip = 'tests_to_skip + " or test_test_server_hostnames[::1-::1] or test_send[request_start-params0-TraceRequestStartParams]"' %}  # [linux]
-{% set tests_to_skip = tests_to_skip + " or test_static_directory_without_read_permission or test_static_file_without_read_permission" %}  # [linux]
-{% set tests_to_skip = 'tests_to_skip + " or test_release_early[pyloop]"' %}
-{% set tests_to_skip = 'tests_to_skip + " or test_no_warnings[aiohttp.worker]"' %}  # [win]
 
 package:
   name: {{ name|lower }}
@@ -31,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -83,20 +64,42 @@ test:
   commands:
     - pip check
     # don't want the docker tests in the autobahn subfolder
-    - rm -rf tests/autobahn  # [unix]
-    - rmdir /s /q tests\autobahn  # [win]
+    - rm -rf tests/autobahn         # [unix]
+    - rmdir /s /q tests\autobahn    # [win]
+
+    {% set tests_to_skip = "_not_a_real_test" %}
     # would requires package time-machine
+    {% set tests_to_skip = tests_to_skip + " or test_expires or test_max_age or test_cookie_jar_clear_expired" %}
     # time sensitive issues on slow CI?
+    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_c[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_bad_chunked_strict_py[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_http_response_parser_strict_headers[c-parser-pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_access_root_of_static_handler[pyloop-index_forbidden]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_heartbeat[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_heartbeat_no_pong[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_heartbeat_no_pong_after_receive_many_messages[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_normal_closure_while_client_sends_msg[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_close_timeout[pyloop]" %}
+    {% set tests_to_skip = tests_to_skip + " or test_client_session_timeout_zero" %}
     # OSError regarding socket assigment
+    {% set tests_to_skip = tests_to_skip + " or test_run_app_preexisting_inet6_socket[pyloop] " %}
+    {% set tests_to_skip = tests_to_skip + " or test_keepalive_timeout_sync_sleep or test_keepalive_timeout_async_sleep or test_HTTP_304[pyloop]" %}
     # CI is too slow for expected speed
+    {% set tests_to_skip = tests_to_skip + " or test_import_time" %}  # [linux]
+
     # Permission errors on linux
+    {% set tests_to_skip = tests_to_skip + " or test_test_server_hostnames[::1-::1] or test_send[request_start-params0-TraceRequestStartParams]" %}  # [linux]
     # Socket assisgnemnt errors on linux
+    {% set tests_to_skip = tests_to_skip + " or test_static_directory_without_read_permission or test_static_file_without_read_permission" %}  # [linux]
+
     # PytestUnraisableExceptionWarning on s390x
+    {% set tests_to_skip = tests_to_skip + " or test_release_early[pyloop]" %}
     # would requires package gunicorn
+    {% set tests_to_skip = tests_to_skip + " or test_no_warnings[aiohttp.worker]" %} # [win]
     # ignore test files due to currently unavailable test dependencies (proxy.py)
     # || true because of unstable pyloop tests. (Time sensitive issues on slow CI?)
-    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || true  # [unix]
-    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || exit /b 0  # [win]
+    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || true          # [unix]
+    - pytest -k "not ({{ tests_to_skip }})" --ignore=tests/test_proxy_functional.py || exit /b 0     # [win]
 
 about:
   home: https://github.com/aio-libs/aiohttp


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5574](https://anaconda.atlassian.net/browse/PKG-5574) 
- [Upstream repository](https://github.com/aio-libs/aiohttp/tree/v3.13.2)
- Requirements: 
  - https://github.com/aio-libs/aiohttp/blob/v3.13.2/pyproject.toml
  - https://github.com/aio-libs/aiohttp/blob/v3.13.2/setup.cfg
  - https://github.com/aio-libs/aiohttp/blob/v3.13.2/setup.py

### Explanation of changes:

- Update host dependencies

### Notes:

- We have to relax pytest-xdist's upper bound in pytest-codspeed to support py314, see https://github.com/AnacondaRecipes/pytest-codspeed-feedstock/pull/8.
- 

[PKG-5574]: https://anaconda.atlassian.net/browse/PKG-5574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ