### PR TITLE
aiohttp v3.13.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp" %}
-{% set version = "3.13.2" %}
+{% set version = "3.13.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
-  sha256: 40176a52c186aefef6eb3cad2cdd30cd06e3afbe88fe8ab2af9c0b90f228daca
+  sha256: a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88
 
 build:
   skip: true  # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,10 @@ requirements:
     # promote to run due to high recommendation from developers
     # https://github.com/aio-libs/aiohttp/blob/acfc2e6e34e36c5afadc665ac3a6ffb5c1e00234/docs/index.rst#library-installation
     - aiodns >=3.3.0
-
+  run_constrained:
+    - brotli-python >=1.2.0  # [python_impl == cpython] 
+    - brotlicffi >=1.2.0  # [python_impl != cpython]
+    - backports.zstd >=1.0.0 # [py<314]
 test:
   imports:
     - aiohttp


### PR DESCRIPTION
aiohttp 3.13.3

**Destination channel:** defaults

### Links

- [PKG-11794](https://anaconda.atlassian.net/browse/PKG-11794) 
- [Upstream repository](https://github.com/aio-libs/aiohttp/tree/v3.13.3)
- [Upstream changelog/diff](http://github.com/aio-libs/aiohttp/releases/tag/v3.13.3)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- Fix for CVE-2025-69223


[PKG-11794]: https://anaconda.atlassian.net/browse/PKG-11794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ