### PR TITLE
Update version to 3.13.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp" %}
-{% set version = "3.13.3" %}
+{% set version = "3.13.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/aiohttp-{{ version }}.tar.gz
-  sha256: a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88
+  sha256: d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38
 
 build:
   skip: true  # [py<39]


### PR DESCRIPTION
aiohttp 3.13.4

**Destination channel:**  defaults

### Links

- [PKG-13362](https://anaconda.atlassian.net/browse/PKG-13362) 
- [Upstream repository](https://github.com/aio-libs/aiohttp)

### Explanation of changes:
- New version number


[PKG-13362]: https://anaconda.atlassian.net/browse/PKG-13362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ